### PR TITLE
fix(oxlint): move unimplemented rules to compat JS plugins

### DIFF
--- a/docs/oxlint-rule-coverage.md
+++ b/docs/oxlint-rule-coverage.md
@@ -9,7 +9,7 @@ Every active rule enforced by `eslint-config-decent` and its oxlint status.
 - 🔌 JS — via standalone JS plugin
 - ❌ N/A — not available (reason noted)
 
-**Totals:** ~393 enforced rules → 298 native, 42 compat, 36 JS plugin, 17 not available (**96% coverage**)
+**Totals:** ~393 enforced rules → 293 native, 46 compat, 36 JS plugin, 18 not available (**95% coverage**)
 
 > Rules explicitly set to `off` are excluded. Recommended config spreads are resolved against `src/oxlint.ts`.
 
@@ -86,7 +86,7 @@ Every active rule enforced by `eslint-config-decent` and its oxlint status.
 | `prefer-const`                | ✅ Native                              |
 | `prefer-numeric-literals`     | ✅ Native                              |
 | `prefer-object-spread`        | ✅ Native                              |
-| `prefer-regex-literals`       | ✅ Native                              |
+| `prefer-regex-literals`       | 🔌 Compat (via `oxlint-plugin-eslint`) |
 | `prefer-template`             | ✅ Native                              |
 | `sort-imports`                | ✅ Native                              |
 | `symbol-description`          | ✅ Native                              |
@@ -94,14 +94,14 @@ Every active rule enforced by `eslint-config-decent` and its oxlint status.
 | `vars-on-top`                 | ✅ Native                              |
 | `yoda`                        | ✅ Native                              |
 
-62 native, 8 compat, 4 N/A — **95%**
+61 native, 9 compat, 4 N/A — **95%**
 
 ## ESLint Core — CJS/ESM (`src/eslint.ts`)
 
 | Rule                           | Status                                                           |
 | ------------------------------ | ---------------------------------------------------------------- |
 | `curly`                        | ✅ Native                                                        |
-| `dot-notation`                 | ✅ Native                                                        |
+| `dot-notation`                 | ❌ N/A (won't implement; use `typescript/dot-notation`)          |
 | `getter-return`                | ✅ Native                                                        |
 | `no-array-constructor`         | ✅ Native                                                        |
 | `no-empty-function`            | ✅ Native                                                        |
@@ -117,7 +117,7 @@ Every active rule enforced by `eslint-config-decent` and its oxlint status.
 | `prefer-arrow-callback`        | 🔌 Compat (via `oxlint-plugin-eslint`)                           |
 | `prefer-promise-reject-errors` | ✅ Native                                                        |
 
-13 native, 1 compat, 2 N/A — **88%**
+12 native, 1 compat, 3 N/A — **81%**
 
 ## ESLint Core — CJS (`src/eslint.ts`)
 
@@ -127,28 +127,28 @@ Every active rule enforced by `eslint-config-decent` and its oxlint status.
 
 ## TypeScript — explicit (`src/typescriptEslint.ts`)
 
-| Rule                                                        | Status              |
-| ----------------------------------------------------------- | ------------------- |
-| `@typescript-eslint/array-type`                             | ✅ Native           |
-| `@typescript-eslint/ban-ts-comment`                         | ✅ Native           |
-| `@typescript-eslint/consistent-type-imports`                | ✅ Native           |
-| `@typescript-eslint/default-param-last`                     | ✅ Native           |
-| `@typescript-eslint/explicit-function-return-type`          | ✅ Native           |
-| `@typescript-eslint/explicit-member-accessibility`          | 🔌 Compat           |
-| `@typescript-eslint/member-ordering`                        | 🔌 Compat           |
-| `@typescript-eslint/naming-convention`                      | 🔌 Compat           |
-| `@typescript-eslint/no-dupe-class-members`                  | ✅ Native           |
-| `@typescript-eslint/no-empty-interface`                     | ✅ Native           |
-| `@typescript-eslint/no-extra-semi`                          | ❌ N/A (deprecated) |
-| `@typescript-eslint/no-loop-func`                           | ✅ Native           |
-| `@typescript-eslint/no-redeclare`                           | ✅ Native           |
-| `@typescript-eslint/no-shadow`                              | ✅ Native           |
-| `@typescript-eslint/no-unnecessary-boolean-literal-compare` | ✅ Native           |
-| `@typescript-eslint/only-throw-error`                       | ✅ Native           |
-| `@typescript-eslint/parameter-properties`                   | ✅ Native           |
-| `@typescript-eslint/restrict-template-expressions`          | ✅ Native           |
-| `@typescript-eslint/return-await`                           | ✅ Native           |
-| `@typescript-eslint/sort-type-constituents`                 | ❌ N/A (deprecated) |
+| Rule                                                        | Status                                  |
+| ----------------------------------------------------------- | --------------------------------------- |
+| `@typescript-eslint/array-type`                             | ✅ Native                               |
+| `@typescript-eslint/ban-ts-comment`                         | ✅ Native                               |
+| `@typescript-eslint/consistent-type-imports`                | ✅ Native                               |
+| `@typescript-eslint/default-param-last`                     | ✅ Native                               |
+| `@typescript-eslint/explicit-function-return-type`          | ✅ Native                               |
+| `@typescript-eslint/explicit-member-accessibility`          | 🔌 Compat (ships native in oxlint 1.61) |
+| `@typescript-eslint/member-ordering`                        | 🔌 Compat                               |
+| `@typescript-eslint/naming-convention`                      | 🔌 Compat                               |
+| `@typescript-eslint/no-dupe-class-members`                  | ✅ Native                               |
+| `@typescript-eslint/no-empty-interface`                     | ✅ Native                               |
+| `@typescript-eslint/no-extra-semi`                          | ❌ N/A (deprecated)                     |
+| `@typescript-eslint/no-loop-func`                           | ✅ Native                               |
+| `@typescript-eslint/no-redeclare`                           | ✅ Native                               |
+| `@typescript-eslint/no-shadow`                              | ✅ Native                               |
+| `@typescript-eslint/no-unnecessary-boolean-literal-compare` | ✅ Native                               |
+| `@typescript-eslint/only-throw-error`                       | ✅ Native                               |
+| `@typescript-eslint/parameter-properties`                   | ✅ Native                               |
+| `@typescript-eslint/restrict-template-expressions`          | ✅ Native                               |
+| `@typescript-eslint/return-await`                           | ✅ Native                               |
+| `@typescript-eslint/sort-type-constituents`                 | ❌ N/A (deprecated)                     |
 
 15 native, 3 compat, 2 N/A — **90%**
 
@@ -302,13 +302,13 @@ Spreads `jsdoc.configs['flat/recommended'].rules`, then applies explicit overrid
 | `jsdoc/require-property-name`                   | ✅ Native |
 | `jsdoc/require-property-type`                   | ✅ Native |
 | `jsdoc/require-returns`                         | ✅ Native |
-| `jsdoc/require-returns-check`                   | ✅ Native |
+| `jsdoc/require-returns-check`                   | 🔌 Compat |
 | `jsdoc/require-yields`                          | ✅ Native |
-| `jsdoc/require-yields-check`                    | ✅ Native |
-| `jsdoc/tag-lines`                               | ✅ Native |
+| `jsdoc/require-yields-check`                    | 🔌 Compat |
+| `jsdoc/tag-lines`                               | 🔌 Compat |
 | `jsdoc/valid-types`                             | 🔌 Compat |
 
-18 native, 5 compat — **100%**
+15 native, 8 compat — **100%**
 
 ## Security (`src/security.ts`)
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "build": "unbuild",
     "test": "tsgo --noEmit --skipLibCheck",
+    "test:oxlint-rules": "node scripts/test-oxlint-rules.mjs",
     "lint:markdown": "prettier --write '**/*.md' '!**/node_modules/**' '!**/dist/**' && markdownlint '**/*.md' --ignore '**/node_modules/**' --ignore '**/dist/**' --config=.github/linters/.markdown-lint.yml --fix",
     "lint:code": "eslint --fix",
     "prelint": "npm run build",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "oxlint-plugin-eslint": ">=1.52.0",
     "@stylistic/eslint-plugin": ">=5.0.0",
     "@vitest/eslint-plugin": ">=1.0.0",
+    "@typescript-eslint/eslint-plugin": ">=8.0.0",
     "eslint-plugin-jsdoc": ">=62.0.0",
     "eslint-plugin-react": ">=7.0.0",
     "eslint-plugin-security": ">=4.0.0",
@@ -99,6 +100,9 @@
       "optional": true
     },
     "oxlint-plugin-eslint": {
+      "optional": true
+    },
+    "@typescript-eslint/eslint-plugin": {
       "optional": true
     },
     "@stylistic/eslint-plugin": {

--- a/scripts/test-oxlint-rules.mjs
+++ b/scripts/test-oxlint-rules.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+// Validates that every native-plugin rule in the oxlint config exists in
+// the installed oxlint binary. Catches the class of bug where we reference
+// rules that oxlint hasn't implemented yet.
+//
+// oxlint's --rules output uses internal source names (e.g. "jest" for vitest,
+// "jsx_a11y" for jsx-a11y, "eslint" for typescript extension rules), so we
+// match by rule name rather than plugin/rule pair.
+
+import { execSync } from 'node:child_process';
+
+import { oxlintConfig } from '../dist/oxlint.mjs';
+
+const config = oxlintConfig({
+  enableReact: true,
+  enableVitest: true,
+  enableNextJs: true,
+  enableTestingLibrary: true,
+});
+
+const nativePlugins = new Set(config.plugins);
+
+function extractNativeRules(rules) {
+  const result = [];
+  for (const key of Object.keys(rules)) {
+    const slash = key.indexOf('/');
+    if (slash === -1) {
+      continue;
+    }
+
+    const plugin = key.slice(0, slash);
+    if (nativePlugins.has(plugin)) {
+      result.push({ configKey: key, plugin, ruleName: key.slice(slash + 1) });
+    }
+  }
+
+  return result;
+}
+
+const allRules = extractNativeRules(config.rules);
+for (const override of config.overrides ?? []) {
+  if (override.rules) {
+    allRules.push(...extractNativeRules(override.rules));
+  }
+}
+
+const seen = new Set();
+const uniqueRules = allRules.filter((rule) => {
+  if (seen.has(rule.configKey)) {
+    return false;
+  }
+
+  seen.add(rule.configKey);
+  return true;
+});
+
+const oxlintVersion = execSync('npx oxlint --version', { encoding: 'utf8' }).trim();
+const rawOutput = execSync('npx oxlint --rules', { encoding: 'utf8' });
+const availableRuleNames = new Set();
+for (const line of rawOutput.split('\n')) {
+  const match = line.match(/^\|\s+(\S+)\s+\|\s+(\S+)\s+\|/);
+  if (!match) {
+    continue;
+  }
+
+  const [, ruleName] = match;
+  if (ruleName === 'Rule' || ruleName === '---') {
+    continue;
+  }
+
+  availableRuleNames.add(ruleName);
+}
+
+const missing = [];
+for (const rule of uniqueRules) {
+  if (!availableRuleNames.has(rule.ruleName)) {
+    missing.push(rule.configKey);
+  }
+}
+
+/* eslint-disable no-console */
+if (missing.length > 0) {
+  console.error(`\n${missing.length} rule(s) in oxlint config not found in oxlint ${oxlintVersion}:\n`);
+  for (const name of missing) {
+    console.error(`  - ${name}`);
+  }
+
+  console.error('\nThese rules must be removed from src/oxlint.ts or moved to a -compat JS plugin.\n');
+  process.exit(1);
+}
+
+console.log(`All ${uniqueRules.length} native-plugin rules verified against oxlint ${oxlintVersion}.`);
+/* eslint-enable no-console */

--- a/src/oxlint.ts
+++ b/src/oxlint.ts
@@ -79,7 +79,6 @@ const eslintBaseRules: Record<string, DummyRule> = {
   'eslint/prefer-exponentiation-operator': 'off',
   'eslint/prefer-numeric-literals': 'error',
   'eslint/prefer-object-spread': 'error',
-  'eslint/prefer-regex-literals': ['error', { disallowRedundantWrapping: true }],
   'eslint/prefer-template': 'error',
   'eslint/sort-imports': ['error', { ignoreCase: true, ignoreDeclarationSort: true, allowSeparatedGroups: true }],
   'eslint/symbol-description': 'error',
@@ -95,7 +94,6 @@ const eslintBaseRules: Record<string, DummyRule> = {
 // CJS/ESM rules that also apply to TS files via typescript extensions
 const eslintCjsEsmRules: Record<string, DummyRule> = {
   'eslint/curly': ['error', 'multi-line'],
-  'eslint/dot-notation': ['error', { allowKeywords: true }],
   'eslint/getter-return': ['error', { allowImplicit: true }],
   'eslint/no-array-constructor': 'error',
   'eslint/no-empty-function': ['error', { allow: ['arrowFunctions', 'functions', 'methods'] }],
@@ -123,6 +121,7 @@ const eslintCompatRules: Record<string, DummyRule> = {
   'eslint-compat/no-restricted-syntax': ['error', 'DebuggerStatement', 'LabeledStatement', 'WithStatement'],
   'eslint-compat/no-undef-init': 'error',
   'eslint-compat/no-unreachable-loop': ['error', { ignore: [] }],
+  'eslint-compat/prefer-regex-literals': ['error', { disallowRedundantWrapping: true }],
 };
 
 const typescriptRules: Record<string, DummyRule> = {
@@ -143,32 +142,6 @@ const typescriptRules: Record<string, DummyRule> = {
   'typescript/default-param-last': 'error',
   'typescript/dot-notation': 'error',
   'typescript/explicit-function-return-type': 'off',
-  'typescript/explicit-member-accessibility': 'error',
-  'typescript/member-ordering': [
-    'error',
-    {
-      default: [
-        'signature',
-        'private-field',
-        'public-field',
-        'protected-field',
-        'public-constructor',
-        'protected-constructor',
-        'private-constructor',
-        'public-method',
-        'protected-method',
-        'private-method',
-      ],
-    },
-  ],
-  'typescript/naming-convention': [
-    'error',
-    {
-      selector: 'enumMember',
-      format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
-      trailingUnderscore: 'forbid',
-    },
-  ],
   'typescript/no-array-delete': 'error',
   'typescript/no-base-to-string': 'error',
   'typescript/no-confusing-non-null-assertion': 'error',
@@ -249,6 +222,36 @@ const typescriptRules: Record<string, DummyRule> = {
   'typescript/use-unknown-in-catch-callback-variable': 'off',
 };
 
+// Gap rules not yet natively supported — covered via typescript-compat JS plugin (@typescript-eslint/eslint-plugin)
+const typescriptCompatRules: Record<string, DummyRule> = {
+  'typescript-compat/explicit-member-accessibility': 'error',
+  'typescript-compat/member-ordering': [
+    'error',
+    {
+      default: [
+        'signature',
+        'private-field',
+        'public-field',
+        'protected-field',
+        'public-constructor',
+        'protected-constructor',
+        'private-constructor',
+        'public-method',
+        'protected-method',
+        'private-method',
+      ],
+    },
+  ],
+  'typescript-compat/naming-convention': [
+    'error',
+    {
+      selector: 'enumMember',
+      format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+      trailingUnderscore: 'forbid',
+    },
+  ],
+};
+
 const importRules: Record<string, DummyRule> = {
   'import/consistent-type-specifier-style': ['error', 'prefer-inline'],
   'import/first': 'error',
@@ -278,15 +281,12 @@ const promiseRules: Record<string, DummyRule> = {
 
 const jsdocRules: Record<string, DummyRule> = {
   // Explicitly configured
-  'jsdoc/check-param-names': 'off',
   'jsdoc/check-tag-names': 'error',
-  'jsdoc/require-description': 'off',
   'jsdoc/require-param': ['error', { enableFixer: false, ignoreWhenAllParamsMissing: true, unnamedRootBase: ['args'] }],
   'jsdoc/require-param-description': 'off',
   'jsdoc/require-param-name': 'error',
   'jsdoc/require-param-type': 'error',
   'jsdoc/require-returns-description': 'off',
-  'jsdoc/require-jsdoc': 'off',
   'jsdoc/require-returns-type': 'off',
 
   // From flat/recommended inheritance
@@ -300,10 +300,7 @@ const jsdocRules: Record<string, DummyRule> = {
   'jsdoc/require-property-name': 'error',
   'jsdoc/require-property-type': 'error',
   'jsdoc/require-returns': 'error',
-  'jsdoc/require-returns-check': 'error',
   'jsdoc/require-yields': 'error',
-  'jsdoc/require-yields-check': 'error',
-  'jsdoc/tag-lines': 'error',
 };
 
 // Gap rules not yet natively supported — covered via jsdoc-compat JS plugin
@@ -312,6 +309,9 @@ const jsdocCompatRules: Record<string, DummyRule> = {
   'jsdoc-compat/check-indentation': 'error',
   'jsdoc-compat/check-types': 'error',
   'jsdoc-compat/require-hyphen-before-param-description': 'error',
+  'jsdoc-compat/require-returns-check': 'error',
+  'jsdoc-compat/require-yields-check': 'error',
+  'jsdoc-compat/tag-lines': 'error',
   'jsdoc-compat/valid-types': 'error',
 };
 
@@ -582,6 +582,7 @@ export function oxlintConfig(options?: OxlintConfigOptions): OxlintConfig {
     { name: 'eslint-compat', specifier: 'oxlint-plugin-eslint' },
     { name: 'unicorn-compat', specifier: 'eslint-plugin-unicorn' },
     { name: 'jsdoc-compat', specifier: 'eslint-plugin-jsdoc' },
+    { name: 'typescript-compat', specifier: '@typescript-eslint/eslint-plugin' },
     { name: 'stylistic-compat', specifier: '@stylistic/eslint-plugin' },
     ...(enableReact ? [{ name: 'react-compat', specifier: 'eslint-plugin-react' }] : []),
     ...(enableVitest ? [{ name: 'vitest-compat', specifier: '@vitest/eslint-plugin' }] : []),
@@ -598,6 +599,7 @@ export function oxlintConfig(options?: OxlintConfigOptions): OxlintConfig {
     ...eslintCjsEsmRules,
     ...eslintCompatRules,
     ...typescriptRules,
+    ...typescriptCompatRules,
     ...importRules,
     ...unicornRules,
     ...unicornCompatRules,


### PR DESCRIPTION
## Summary

oxlint 1.60.0 rejects config files that reference rules it doesn't ship, causing parse-time
"Rule 'X' not found in plugin 'Y'" errors for consumers. This PR moves 7 active rules from
native plugin prefixes to their respective `-compat` JS plugin aliases (preserving enforcement),
removes 3 inactive (`off`) rules and 1 rule covered by its typescript variant, and adds a
regression test.

### Rules moved to compat plugins

| Rule | From | To | Upstream |
|---|---|---|---|
| `prefer-regex-literals` | `eslint/` | `eslint-compat/` | [oxc#479](https://github.com/oxc-project/oxc/issues/479) — not implemented |
| `explicit-member-accessibility` | `typescript/` | `typescript-compat/` | [oxc#2180](https://github.com/oxc-project/oxc/issues/2180) — merged after 1.60.0 cut, ships in 1.61 |
| `member-ordering` | `typescript/` | `typescript-compat/` | [oxc#2180](https://github.com/oxc-project/oxc/issues/2180) — PR closed, not implemented |
| `naming-convention` | `typescript/` | `typescript-compat/` | [oxc#2180](https://github.com/oxc-project/oxc/issues/2180) — not implemented |
| `require-returns-check` | `jsdoc/` | `jsdoc-compat/` | [oxc#1170](https://github.com/oxc-project/oxc/issues/1170) — not implemented |
| `require-yields-check` | `jsdoc/` | `jsdoc-compat/` | [oxc#1170](https://github.com/oxc-project/oxc/issues/1170) — not implemented |
| `tag-lines` | `jsdoc/` | `jsdoc-compat/` | [oxc#1170](https://github.com/oxc-project/oxc/issues/1170) — not implemented |

### Rules removed (no enforcement loss)

| Rule | Reason |
|---|---|
| `eslint/dot-notation` | oxlint won't implement — covered by native `typescript/dot-notation` ([oxc#479](https://github.com/oxc-project/oxc/issues/479)) |
| `jsdoc/check-param-names` | Was `off` |
| `jsdoc/require-description` | Was `off` |
| `jsdoc/require-jsdoc` | Was `off` |

### New: `typescript-compat` JS plugin

Adds a `typescript-compat` plugin alias backed by `@typescript-eslint/eslint-plugin` (already
a transitive dependency of `typescript-eslint`), following the same pattern as `eslint-compat`,
`jsdoc-compat`, etc.

### Regression test

`scripts/test-oxlint-rules.mjs` validates every native-plugin rule in the generated config
against `oxlint --rules`. Run via `npm run test:oxlint-rules` (requires `npm run build` first).

Related: [oxc#20895](https://github.com/oxc-project/oxc/issues/20895) — oxlint's parse-time
failure on unknown rules.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` (type check) passes
- [x] `npm run lint:code` passes
- [x] `npm run test:oxlint-rules` — all 300 native rules verified against oxlint 1.60.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)