### PR TITLE
fix: drop redundant FixupPluginDefinition casts

### DIFF
--- a/src/import.ts
+++ b/src/import.ts
@@ -1,10 +1,10 @@
-import { type FixupPluginDefinition, fixupPluginRules } from '@eslint/compat';
+import { fixupPluginRules } from '@eslint/compat';
 import { type Config } from '@eslint/config-helpers';
 import importPlugin from 'eslint-plugin-import-x';
 
 const base: Config = {
   plugins: {
-    import: fixupPluginRules(importPlugin as unknown as FixupPluginDefinition),
+    import: fixupPluginRules(importPlugin),
   },
   rules: {
     'import/consistent-type-specifier-style': ['error', 'prefer-inline'],

--- a/src/nextjs.ts
+++ b/src/nextjs.ts
@@ -1,4 +1,3 @@
-import { type FixupPluginDefinition } from '@eslint/compat';
 import { fixupPluginRules } from '@eslint/compat';
 import { type Config, type RuleConfig } from '@eslint/config-helpers';
 import nextJs from '@next/eslint-plugin-next';
@@ -11,7 +10,7 @@ for (const ruleName of Object.keys({ ...nextJs.configs.recommended.rules })) {
 
 const base: Config = {
   plugins: {
-    '@next/next': fixupPluginRules(nextJs as FixupPluginDefinition),
+    '@next/next': fixupPluginRules(nextJs),
   },
   rules: {
     ...recommendedRules,

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,4 +1,3 @@
-import { type FixupPluginDefinition } from '@eslint/compat';
 import { fixupPluginRules } from '@eslint/compat';
 import { type Config } from '@eslint/config-helpers';
 import a11y from 'eslint-plugin-jsx-a11y';
@@ -17,7 +16,7 @@ const base: Config = {
   },
   plugins: {
     'jsx-a11y': a11y,
-    react: fixupPluginRules(react as FixupPluginDefinition),
+    react: fixupPluginRules(react),
     'react-hooks': reactHooks,
   },
   rules: {

--- a/src/testingLibrary.ts
+++ b/src/testingLibrary.ts
@@ -1,11 +1,10 @@
-import { type FixupPluginDefinition } from '@eslint/compat';
 import { fixupPluginRules } from '@eslint/compat';
 import { type Config } from '@eslint/config-helpers';
 import testingLibrary from 'eslint-plugin-testing-library';
 
 const base: Config = {
   plugins: {
-    'testing-library': fixupPluginRules(testingLibrary as FixupPluginDefinition) as typeof testingLibrary,
+    'testing-library': fixupPluginRules(testingLibrary),
   },
   rules: {
     ...testingLibrary.configs['flat/react'].rules,


### PR DESCRIPTION
## Summary
- `typescript-eslint` 8.59.3 (incoming via renovate PR #371) flags `as FixupPluginDefinition` on `fixupPluginRules(...)` arguments as unnecessary since the receiver already accepts that type
- `eslint --fix` strips the assertions, which leaves the `FixupPluginDefinition` type import orphaned and trips `@typescript-eslint/no-unused-vars`
- Remove the redundant casts and the now-unused imports across `import.ts`, `nextjs.ts`, `react.ts`, and `testingLibrary.ts` so lint passes both with the current and upcoming `typescript-eslint` versions

## Test plan
- [x] `npm run build` passes
- [x] `npm test` (tsgo typecheck) passes
- [x] `npx eslint --fix .` exits clean on current `typescript-eslint@8.58.2`
- [x] Verified lint passes when bumped to PR #371's `typescript-eslint@8.59.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)